### PR TITLE
0.1.1-dev2: Fix Dockerfile and update .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,6 +18,7 @@ env/
 .vscode/
 .idea/
 .git/
+.github/
 .gitignore
 README.md
 *.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2025-03-01
+
 ### Added
 
 - Add `CODE_OF_CONDUCT.md` file and `CONTRIBUTING.md` file.
@@ -15,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update the README.md file with acknowledgements.
+- Add GitHub Actions and Docker badges to README.md.
 
 ### Fixed
 
@@ -34,7 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Changelog 
 
 
-[Unreleased]: https://github.com/ZhipengHe/NEM-Dashboard/compare/v0.0.1...HEAD
-[0.1.0]: https://github.com/ZhipengHe/NEM-Dashboard/releases/tag/v0.0.1
+[Unreleased]: https://github.com/ZhipengHe/NEM-Dashboard/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/ZhipengHe/NEM-Dashboard/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/ZhipengHe/NEM-Dashboard/releases/tag/v0.1.0
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update the README.md file with acknowledgements.
 
+### Fixed
+
+- Fix the CMD command in the Dockerfile (issue #4). 
+
 
 ## [0.1.0] - 2025-02-28
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ FROM python:3.11-slim
 # Set the working directory inside the container
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y \
-    && rm -rf /var/lib/apt/lists/*
+RUN RUN apt-get update && rm -rf /var/lib/apt/lists/*
+
 
 # Copy the requirements file into the container
 COPY requirements.txt .
@@ -30,4 +30,4 @@ LABEL author="Zhipeng He" \
       description="Streamlit application container for NEM data analysis"
 
 # Run the Streamlit app
-CMD ["streamlit", "run", "app.py"]
+CMD ["sh", "-c", "streamlit run app.py --server.port=$STREAMLIT_SERVER_PORT --server.address=$STREAMLIT_SERVER_ADDRESS"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,6 @@ FROM python:3.11-slim
 # Set the working directory inside the container
 WORKDIR /app
 
-RUN RUN apt-get update && rm -rf /var/lib/apt/lists/*
-
-
 # Copy the requirements file into the container
 COPY requirements.txt .
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # NEM Dashboard
 
+[![GitHub Actions Build](https://img.shields.io/github/actions/workflow/status/ZhipengHe/NEM-Dashboard/docker-build-push.yml)](https://github.com/ZhipengHe/NEM-Dashboard/actions/workflows/docker-build-push.yml) 
+[![Docker Image Version](https://img.shields.io/docker/v/zhipenghe/nem-dashboard)](https://hub.docker.com/r/zhipenghe/nem-dashboard) 
+[![Docker Image Size](https://img.shields.io/docker/image-size/zhipenghe/nem-dashboard)](https://hub.docker.com/r/zhipenghe/nem-dashboard) 
+[![Website](https://img.shields.io/website?url=https%3A%2F%2Fnem.zhipenghe.me)](https://nem.zhipenghe.me)
+[![GitHub Issues or Pull Requests](https://img.shields.io/github/issues/ZhipengHe/NEM-Dashboard)](https://github.com/ZhipengHe/NEM-Dashboard/issues)
+[![License](https://img.shields.io/github/license/ZhipengHe/NEM-Dashboard)](LICENSE)
+
+
 This is a simple dashboard for Australian National Electricity Market (NEM) data. The data is extracted from the AEMO website by using Python package [NEMOSIS](https://github.com/UNSW-CEEM/NEMOSIS). The extracted data is stored in folder `data` and the dashboard is created using [Streamlit](https://streamlit.io/).
 
 ## Installation


### PR DESCRIPTION
Fix #4 
- Correct CMD command to support dynamic server port and address configuration
- Remove redundant RUN command in Dockerfile
- Add .github/ to .dockerignore
- Update CHANGELOG with Dockerfile CMD fix details