### PR TITLE
Improve Outage Analysis visualization in Topic 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,12 @@ data/raw_data_cache/
 data/concatenated_data/
 
 .DS_Store
+
+# python
+*.pyc
+*.pyo
+*.pyd
+__pycache__/
+
+# Jupyter Notebook
+.ipynb_checkpoints/

--- a/topics/Topic-2-Outage-Analysis.py
+++ b/topics/Topic-2-Outage-Analysis.py
@@ -58,8 +58,11 @@ with st.container():
             # Count outages per month
             outages_per_month = data.groupby("YEAR_MONTH").size().reset_index(name="COUNT")
 
+            # Convert YEAR_MONTH to datetime for proper Altair processing
+            outages_per_month["YEAR_MONTH"] = pd.to_datetime(outages_per_month["YEAR_MONTH"])
+
             # Compute the overall mean of outages.
-            mean_value = outages_per_month['COUNT'].mean()
+            mean_value = round(outages_per_month['COUNT'].mean())
 
             # Plot outages over time
             base = alt.Chart(outages_per_month).encode(
@@ -77,7 +80,7 @@ with st.container():
                 y=alt.Y("baseline:Q"),
                 y2=alt.Y2("COUNT:Q")
             ).transform_filter(
-                alt.datum.COUNT > mean_value
+                alt.datum.COUNT >= mean_value
             ).transform_calculate(
                 baseline=str(mean_value)
             )


### PR DESCRIPTION
- Convert YEAR_MONTH to datetime for proper Altair chart processing
- Round mean outage count for clearer baseline calculation
- Adjust baseline filter to include months with outages equal to or above mean

Fix #20 